### PR TITLE
Update kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
   curl
 
-ARG KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.4.0/bin/linux/amd64/kubectl
+ARG KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
 RUN cd /usr/local/bin && curl -O $KUBECTL_URL && chmod 755 kubectl
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Running with kubectl v1.4.0 failed to delete pods.
The problem was solved by updating to v1.8.0 and rebuilding the image.