### PR TITLE
update kubectl to v1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
   curl
 
-ARG KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
+ARG KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl
 RUN cd /usr/local/bin && curl -O $KUBECTL_URL && chmod 755 kubectl
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
`kubectl delete` yields:

```
error: group map[...] is already registered
```

if kubectl is too old.