### PR TITLE
add variable FORCE to disable graceful pod deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A few environment variables are available for configuration:
 
 * `DELAY`: seconds between selecting and deleting a pod. Defaults to `30`.
 * `NAMESPACE`: the namespace to select a pod from. Defaults to `default`.
+* `FORCE`: delete pods with `--force` and `--grace-period=0`. Defaults to `false`.
 
 Example Kubernetes config is included at [`config/kubernetes/production/deployment.yaml`](./config/kubernetes/production/deployment.yaml)
 

--- a/chaos.sh
+++ b/chaos.sh
@@ -4,8 +4,14 @@ set -ex
 
 : ${DELAY:=30}
 : ${NAMESPACE:=default}
+: ${FORCE:=false}
 
 while true; do
+  if [ "${FORCE}" == "true" ]; then
+    CMD_FORCE="--force --grace-period=0"
+  else
+    CMD_FORCE=""
+  fi
   kubectl \
     --namespace "${NAMESPACE}" \
     -o 'jsonpath={.items[*].metadata.name}' \
@@ -14,6 +20,6 @@ while true; do
       shuf | \
       head -n 1 |
       xargs -t --no-run-if-empty \
-        kubectl --namespace "${NAMESPACE}" delete pod
+        kubectl --namespace "${NAMESPACE}" delete pod ${CMD_FORCE}
   sleep "${DELAY}"
 done

--- a/chaos.sh
+++ b/chaos.sh
@@ -6,12 +6,13 @@ set -ex
 : ${NAMESPACE:=default}
 : ${FORCE:=false}
 
+if [ "${FORCE}" == "true" ]; then
+  CMD_FORCE="--force --grace-period=0"
+else
+  CMD_FORCE=""
+fi
+
 while true; do
-  if [ "${FORCE}" == "true" ]; then
-    CMD_FORCE="--force --grace-period=0"
-  else
-    CMD_FORCE=""
-  fi
   kubectl \
     --namespace "${NAMESPACE}" \
     -o 'jsonpath={.items[*].metadata.name}' \


### PR DESCRIPTION
Adds an option to toggle `--force` and `--grace-period=0`.

Helps the chaos monkey to create more chaos and be more reckless.